### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ sudo ln -s /opt/arm/arm.yaml /etc/arm/
 
 - Edit your "config" file (located at /opt/arm/arm.yaml) to determine what options you'd like to use.  Pay special attention to the 'directory setup' section and make sure the 'arm' user has write access to wherever you define these directories.
 
-- Edit the music config file (located at /home/arm/.abcde.conf)
+- Edit the music config file (located at /home/arm/.abcde.conf) paying special attention to `OUTPUTDIR=` (line 66) if you do not plan to have the final destination locally. Wherever this location is the `arm` user needs to have permission read and write over the entire root path.
 
 - To rip Blu-Rays after the MakeMKV trial is up you will need to purchase a license key or while MakeMKV is in BETA you can get a free key (which you will need to update from time to time) here:  https://www.makemkv.com/forum2/viewtopic.php?f=5&t=1053 and create /home/arm/.MakeMKV/settings.conf with the contents:
 


### PR DESCRIPTION
Made a clarification in the README about the abcde conf file line 66 permission issue. If the system is not created with the arm user in mind but rather added on (as show in the beginning of the walk through) the final destination output directory might not have the appropriate permissions. This edit is to clarify that this location is set appropriately.